### PR TITLE
Fix mistype in the `20-rs-hello-world.yaml`

### DIFF
--- a/website/docs/kubernetes/40-replicaset-and-service/20-replicaset.md
+++ b/website/docs/kubernetes/40-replicaset-and-service/20-replicaset.md
@@ -20,18 +20,18 @@ metadata:
   name: smpl-go-web-rs
   labels:
       app: smpl-go-web-a
-      tier: fontend
+      tier: frontend
 spec:
   replicas: 1
   selector:
     matchLabels:
-      tier: fontend
+      tier: frontend
   template:
     metadata:
       labels:
         app: smpl-go-web-a
         version: "1"
-        tier: fontend  
+        tier: frontend  
     spec:
       containers:
         - name: smpl-go-web-c


### PR DESCRIPTION
Replace from fontend to frontend in the 20-rs-hello-world.yaml that you can find on .../kubernetes/40-replicaset-and-service/replicasets page